### PR TITLE
uncomment RoleSeeder method calls in run()

### DIFF
--- a/database/seeds/RoleSeeder.php
+++ b/database/seeds/RoleSeeder.php
@@ -13,10 +13,10 @@ class RoleSeeder extends Seeder {
 	
 	public function run()
 	{
-		// $this->command->info('Seeding roles.');
+		$this->command->info('Seeding roles.');
 		// 
-		// $this->runMaster();
-		// $this->runBoards();
+		$this->runMaster();
+		$this->runBoards();
 	}
 	
 	public function runMaster()


### PR DESCRIPTION
fix SQL errors when executing artisan db:seed

[Illuminate\Database\QueryException]                                                                                 
  SQLSTATE[23000]: Integrity constraint violation: 1452 Cannot add or update a child row: a foreign key constraint fa  
  ils (`infinity`.`user_roles`, CONSTRAINT `user_roles_role_id_foreign` FOREIGN KEY (`role_id`) REFERENCES `roles` (`  
  role_id`) ON DELETE CASCADE ON UPDATE CASCADE) (SQL: insert into `user_roles` (`user_id`, `role_id`) values (1, 2)) 

[PDOException]                                                                                                       
  SQLSTATE[23000]: Integrity constraint violation: 1452 Cannot add or update a child row: a foreign key constraint fa  
  ils (`infinity`.`user_roles`, CONSTRAINT `user_roles_role_id_foreign` FOREIGN KEY (`role_id`) REFERENCES `roles` (`  
  role_id`) ON DELETE CASCADE ON UPDATE CASCADE)